### PR TITLE
Check if syslog or rsyslog is installed before restart logging

### DIFF
--- a/waptserver/deb/DEBIAN/postinst
+++ b/waptserver/deb/DEBIAN/postinst
@@ -79,7 +79,7 @@ os.chmod('/usr/bin/wapt-scanpackages', 0o755)
 os.chmod('/usr/bin/wapt-signpackages', 0o755)
 os.chmod('/usr/bin/waptpython',0o755)
 
-aptCache = apt.Cache(
+aptCache = apt.Cache()
 aptCache.open()
 if aptCache['syslog-ng'].is_installed:
     print("Restarting syslog-ng")

--- a/waptserver/deb/DEBIAN/postinst
+++ b/waptserver/deb/DEBIAN/postinst
@@ -83,7 +83,7 @@ aptCache = apt.Cache()
 aptCache.open()
 if aptCache['syslog-ng'].is_installed:
     print("Restarting syslog-ng")
-    runt('systemctl restart syslog-ng')
+    run('systemctl restart syslog-ng')
 elif aptCache['rsyslog'].is_installed:
     print("Restarting rsyslog")
     run('systemctl restart rsyslog')

--- a/waptserver/deb/DEBIAN/postinst
+++ b/waptserver/deb/DEBIAN/postinst
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import time
+import apt
 
 
 def run(*args, **kwargs):
@@ -78,9 +79,14 @@ os.chmod('/usr/bin/wapt-scanpackages', 0o755)
 os.chmod('/usr/bin/wapt-signpackages', 0o755)
 os.chmod('/usr/bin/waptpython',0o755)
 
-
-print("Restarting rsyslog")
-run('systemctl restart rsyslog')
+aptCache = apt.Cache(
+aptCache.open()
+if aptCache['syslog-ng'].is_installed:
+    print("Restarting syslog-ng")
+    runt('systemctl restart syslog-ng')
+elif aptCache['rsyslog'].is_installed:
+    print("Restarting rsyslog")
+    run('systemctl restart rsyslog')
 
 def check_if_running(process_name):
     try:

--- a/waptserver/deb/DEBIAN/postinst
+++ b/waptserver/deb/DEBIAN/postinst
@@ -78,9 +78,21 @@ os.chmod('/usr/bin/wapt-scanpackages', 0o755)
 os.chmod('/usr/bin/wapt-signpackages', 0o755)
 os.chmod('/usr/bin/waptpython',0o755)
 
+devnull = open(os.devnull,"w")
+syslogng_eval= subprocess.call(["dpkg","-s","syslog-ng"],stdout=devnull,stderr=subprocess.STDOUT)
+devnull.close()
+if syslogng_eval == 0:
+        print "Restarting syslog-ng"
+        run('systemctl restart syslog-ng')
 
-print("Restarting rsyslog")
-run('systemctl restart rsyslog')
+devnull = open(os.devnull,"w")
+rsyslog_eval= subprocess.call(["dpkg","-s","rsyslog"],stdout=devnull,stderr=subprocess.STDOUT)
+devnull.close()
+if rsyslog_eval == 0:
+        print "Restarting rsyslog"
+        run('systemctl restart rsyslog')
+
+
 
 def check_if_running(process_name):
     try:

--- a/waptserver/deb/DEBIAN/postinst
+++ b/waptserver/deb/DEBIAN/postinst
@@ -5,7 +5,6 @@ import os
 import shutil
 import sys
 import time
-import apt
 
 
 def run(*args, **kwargs):


### PR DESCRIPTION
I improved the postinst file to consider if the server has syslog or rsyslog installed.

That way the postinst script will restart the right logging system.
